### PR TITLE
feat: support software list/update operations for child devices

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,8 @@
-dist/
+*.deb
+*.apk
+*.rpm
+dist/*
+!dist/.gitkeep
 main
 output/
+.env

--- a/demo/README.md
+++ b/demo/README.md
@@ -1,0 +1,67 @@
+# Demo
+
+## Getting started
+
+1. Build then copy the artifacts from the experimental thin-edge.io branch - [exp-topic-prefix](https://github.com/reubenmiller/thin-edge.io/tree/exp-topic-prefix)
+
+    ```sh
+    # from the thin-edge.io repo
+    just release
+    ```
+
+    Then copy the built debian packages to this project
+
+    ```sh
+    cp target/aarch64-unknown-linux-musl/debian/*.deb tedge-mapper-template/demo/dist
+    ```
+
+2. Build the latest tedge-mapper-template (from this repo) and copy the specific artifact to the `demo/dist` folder
+
+    ```sh
+    just release-local
+    cp dist/tedge-mapper-template_*arm64*deb demo/dist/
+    ```
+
+    Note: You will have to change the `arm64` to suite your architecture of your current setup
+
+2. Start the docker compose project
+
+    ```sh
+    cd demo
+    just up
+    ```
+
+3. View the logs for the tedge-mapper-template running on the main device
+
+    ```sh
+    just logs-main-mapper-template
+    ```
+
+4. Open a new console and log the tedge-agent running on the child device
+
+    ```sh
+    cd demo
+    just logs-child01-agent
+    ```
+
+5. Create a software update operation for the child01 device in Cumulocity
+
+    You can use `go-c8y-cli` to create the operation if you don't want to use the UI
+
+    ```sh
+    c8y operations create --device "{child__mo_id}" --description "install software" --template "{c8y_SoftwareUpdate:[{name:'dummy1',version:'1.0.0::dummy',url:'',softwareType:'dummy',action:'install'}]}"
+    ```
+
+    Example
+
+    ```sh
+    c8y operations create --device "862000795" --description "install software" --template "{c8y_SoftwareUpdate:[{name:'dummy1',version:'1.0.0::dummy',url:'',softwareType:'dummy',action:'install'}]}"
+    ```
+
+    If everything works properly you should see the software update operation be handled successfully by the `tedge-agent` and the `tedge-mapper-template` is doing all of the cloud message routing.
+
+6. You can stop the demo by using
+
+    ```sh
+    just down
+    ```

--- a/demo/docker-compose.yaml
+++ b/demo/docker-compose.yaml
@@ -1,0 +1,18 @@
+version: '3'
+services:
+  tedge:
+    build:
+      dockerfile: ./images/main.dockerfile
+    privileged: true
+    networks:
+    - tedge
+
+  child01:
+    build:
+      dockerfile: ./images/child.dockerfile
+    privileged: true
+    networks:
+    - tedge
+
+networks:
+  tedge:

--- a/demo/images/child.dockerfile
+++ b/demo/images/child.dockerfile
@@ -1,0 +1,22 @@
+FROM ghcr.io/thin-edge/tedge-demo-main-systemd:20230517.2
+
+COPY dist/tedge_*.deb /tmp/
+COPY dist/tedge-agent*.deb /tmp/
+COPY dist/tedge-dummy-plugin_*.deb /tmp/
+
+# Install component which will act like a child device
+RUN dpkg -i /tmp/tedge_*.deb \
+    && dpkg -i /tmp/tedge-agent*.deb \
+    && dpkg -i /tmp/tedge-dummy-plugin*.deb
+
+# Overwrite tedge-agent setup
+COPY images/files/tedge-agent.service /lib/systemd/system/
+
+# bootstrapping settings
+ENV BOOTSTRAP=0
+ENV CONNECT=0
+ENV INSTALL=0
+ENV SHOULD_PROMPT=0
+
+# custom scripts
+COPY images/files/50-child-setup.sh /etc/boostrap/post.d/

--- a/demo/images/files/50-child-setup.sh
+++ b/demo/images/files/50-child-setup.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+echo "Enabling dummy sm-plugin"
+
+if [ ! -f /etc/tedge/sm-plugins/dummy ]; then
+    ln -s /usr/bin/tedge-dummy-plugin /etc/tedge/sm-plugins/dummy
+fi
+
+# Removing other sm-plugins
+rm -f /etc/tedge/sm-plugins/container*
+
+systemctl start tedge-agent
+systemctl enable tedge-agent

--- a/demo/images/files/50-main-setup.sh
+++ b/demo/images/files/50-main-setup.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+
+echo "Creating a local child device" >&2
+
+# For now prefix the child device with the device id (until the registration can be fixed)
+# We will only concentrate on the operation handling for now
+DEVICE_ID=$(tedge config get device.id)
+CHILD=child01
+CHILD_DIR="/etc/tedge/operations/c8y/${DEVICE_ID}_${CHILD}"
+sudo -u tedge mkdir -p "$CHILD_DIR"
+sudo -u tedge touch "$CHILD_DIR/c8y_SoftwareUpdate"
+
+echo "Stopping tedge-mapper-c8y"
+sudo systemctl disable tedge-mapper-c8y
+sudo systemctl stop tedge-mapper-c8y
+
+sudo systemctl disable tedge-container-monitor ||:
+sudo systemctl stop tedge-container-monitor ||:

--- a/demo/images/files/tedge-agent.service
+++ b/demo/images/files/tedge-agent.service
@@ -1,0 +1,16 @@
+[Unit]
+Description=tedge-agent is a thin-edge.io component to support operations.
+After=syslog.target network.target mosquitto.service
+
+[Service]
+User=tedge
+RuntimeDirectory=tedge-agent
+Environment="EXP_TOPIC_PREFIX=tedge/child01"
+Environment="TEDGE_MQTT_CLIENT_HOST=tedge"
+ExecStart=/usr/bin/tedge-agent --client-id child01
+Restart=on-failure
+RestartPreventExitStatus=255
+RestartSec=5
+
+[Install]
+WantedBy=multi-user.target

--- a/demo/images/main.dockerfile
+++ b/demo/images/main.dockerfile
@@ -1,0 +1,11 @@
+FROM ghcr.io/thin-edge/tedge-demo-main-systemd:20230517.2
+
+# Install
+COPY dist/tedge*.deb /setup/build/
+COPY dist/c8y*.deb /setup/build/
+COPY dist/tedge-mapper-template*.deb" /tmp/
+RUN dpkg -i /tmp/*.deb \
+    && systemctl enable tedge-mapper-template.service
+
+# custom scripts
+COPY images/files/50-main-setup.sh /etc/boostrap/post.d/

--- a/demo/justfile
+++ b/demo/justfile
@@ -1,0 +1,31 @@
+set positional-arguments
+set dotenv-load
+
+# Start the demo
+up:
+    docker compose up -d --build
+
+# Stop the demo
+down:
+    docker compose down -v
+
+# Bootstrap
+bootstrap:
+    docker compose exec tedge env C8Y_BASEURL=${C8Y_BASEURL:-} C8Y_USER=${C8Y_USER:-} C8Y_PASSWORD=${C8Y_PASSWORD:-} DEVICE_ID=${DEVICE_ID:-} bootstrap.sh --install --install-sourcedir /setup/build/
+    docker compose exec child01 bootstrap.sh
+
+# Shell into main device
+shell-main *args='bash':
+    docker compose exec tedge {{args}}
+
+# Shell into child device
+shell-child01 *args='bash':
+    docker compose exec child01 {{args}}
+
+# Show logs of the tedge-mapper-template service
+logs-main-mapper-template:
+    docker compose exec tedge journalctl -fu tedge-mapper-template
+
+# Show logs of the tedge-agent running on the child device
+logs-child01-agent:
+    docker compose exec child01 journalctl -fu tedge-agent

--- a/pkg/service/factory.go
+++ b/pkg/service/factory.go
@@ -163,7 +163,23 @@ func NewMetaData() map[string]any {
 
 				}
 			}
-
+		}
+	} else {
+		// TESTING ONLY: Provide a way for testing without having tedge installed
+		// The environment variables will be normalized to mimic the tedge config list
+		// settings.
+		for _, env := range os.Environ() {
+			// Only include env variables starting with TEDGE_ROUTE
+			// to limit amount of spam in the templates and to limit
+			// exposing potential secrets to templates
+			if !strings.HasPrefix(env, "TEDGE_") && !strings.HasPrefix(env, "TEDGE_ROUTE") {
+				continue
+			}
+			key, value, found := strings.Cut(env, "=")
+			if found && value != "" {
+				keyNormalized := strings.ToLower(strings.ReplaceAll(strings.TrimPrefix(key, "TEDGE_"), ".", "_"))
+				meta[keyNormalized] = value
+			}
 		}
 	}
 	return meta

--- a/routes/c8y-operations-json.yaml
+++ b/routes/c8y-operations-json.yaml
@@ -68,7 +68,7 @@ routes:
         if ctx.serial == device_id || ctx.serial == 'not-set'  then
           'tedge/commands/req/' + partial
         else
-          'tedge/commands/' + ctx.serial + '/req/' + partial
+          'tedge/%/commands/req/' % [ctx.localSerial, partial]
       ;
 
       {
@@ -89,7 +89,7 @@ routes:
         if ctx.serial == device_id || ctx.serial == 'not-set'  then
           'tedge/commands/req/' + partial
         else
-          'tedge/commands/' + ctx.serial + '/req/' + partial
+          'tedge/%/commands/req/%s' % [ctx.localSerial, partial]
       ;
       {
           message: {},
@@ -106,7 +106,7 @@ routes:
         if ctx.serial == device_id || ctx.serial == 'not-set' then
           'tedge/commands/req/' + partial
         else
-          'tedge/' + serial + '/commands/req/' + partial
+          'tedge/%/commands/req/%s' % [ctx.localSerial, partial]
       ;
       local params = std.get(message.payload, 'c8y_UploadConfigFile', {});
       {
@@ -130,7 +130,7 @@ routes:
         if ctx.serial == device_id || ctx.serial == 'not-set'  then
           'tedge/commands/req/' + partial
         else
-          'tedge/commands/' + ctx.serial + '/req/' + partial
+          'tedge/%/commands/req/%s' % [ctx.localSerial, partial]
       ;
       local fragment = std.get(message.payload, 'c8y_DownloadConfigFile', {});
       {
@@ -195,7 +195,7 @@ routes:
         if ctx.serial == device_id || ctx.serial == 'not-set'  then
           'tedge/commands/req/' + partial
         else
-          'tedge/' + ctx.serial + '/commands/req/' + partial
+          'tedge/%/commands/req/%s' % [ctx.localSerial, partial]
       ;
 
       local params = std.get(message.payload, ctx.opType, {});
@@ -264,6 +264,15 @@ routes:
       local status = std.get(message, 'status', 'unknown');
       local reason = std.get(message, 'reason', 'unknown');
 
+      # Check if tedge can be modified to preserve the _ctx property
+      local device_id = std.get(meta, 'device_id', '');
+      local local_serial = std.split(topic, "/")[1];
+      local serial = if std.startsWith(local_serial, device_id) then
+          local_serial
+        else
+          '%s_%s' % [device_id, local_serial]
+        ;
+
       local getTemplate = function(s)
         local states = {
           executing: '501,c8y_SoftwareUpdate',
@@ -275,5 +284,7 @@ routes:
 
       {
         raw_message: getTemplate(status),
-        topic: 'c8y/s/us/%s' % ctx.serial,
+
+        # TODO: replace serial with ctx.serial once the operation schema allow extra fields
+        topic: 'c8y/s/us/%s' % serial,
       }

--- a/routes/c8y-operations-json.yaml
+++ b/routes/c8y-operations-json.yaml
@@ -147,11 +147,13 @@ routes:
         if ctx.serial == device_id || ctx.serial == 'not-set'  then
           'tedge/commands/req/' + partial
         else
-          'tedge/commands/' + ctx.serial + '/req/' + partial
+          'tedge/%s/commands/req/%s' %[ctx.localSerial, partial]
       ;
 
+      local defaultType = std.get(meta, 'software_plugin_default', 'apt');
+
       local types = std.set([
-        item.softwareType
+        std.get(item, 'softwareType', defaultType)
         for item in message.payload.c8y_SoftwareUpdate
       ]);
 
@@ -168,7 +170,7 @@ routes:
                   action: software.action,
                 }
                 for software in message.payload.c8y_SoftwareUpdate
-                if software.softwareType == type
+                if std.get(software, 'softwareType', defaultType) == type
               ]
             }
             for type in types

--- a/routes/c8y-operations-json.yaml
+++ b/routes/c8y-operations-json.yaml
@@ -39,10 +39,14 @@ routes:
               'https://' + std.get(meta, 'c8y_http', std.get(meta.env, 'TEDGE_ROUTE_C8Y_BASEURL', ''))
             ),
             _ctx: {
+              local _ctx = self,
               local external_childid = _.Get(message, 'deviceExternalIDs.externalIds.0.externalId', null),
               local external_id = _.Get(message, 'externalSource.externalId', 'not-set'),
+              local device_id = std.get(meta, 'device_id', ''),
 
-              serial: if external_childid != null then external_childid else external_childid,
+              serial: if external_childid != null then external_childid else external_id, 
+              localSerial: if std.startsWith(_ctx.serial, device_id) then _ctx.serial[std.length(device_id)+1:] else _ctx.serial,
+
               deviceID: std.get(message, 'deviceId', ''),
               agentID: std.get(message, 'agentId', ''),
               operationID: std.get(message, 'id', ''),
@@ -226,7 +230,7 @@ routes:
 #
 # Operation Transitions
 #
-- name: status updates
+- name: software update (main device)
   topic: tedge/commands/res/software/update
   description: Handle the operation updates and send the status back to the cloud
   template:
@@ -248,4 +252,28 @@ routes:
       {
         raw_message: getTemplate(status),
         topic: 'c8y/s/us',
+      }
+
+- name: software update (child devices)
+  topic: tedge/+/commands/res/software/update
+  description: Handle the operation updates and send the status back to the cloud
+  template:
+    type: jsonnet
+    value: |
+      local id = std.get(message, 'id', 'unknown');
+      local status = std.get(message, 'status', 'unknown');
+      local reason = std.get(message, 'reason', 'unknown');
+
+      local getTemplate = function(s)
+        local states = {
+          executing: '501,c8y_SoftwareUpdate',
+          successful: '503,c8y_SoftwareUpdate',
+          failed: '502,c8y_SoftwareUpdate,"%s"' % reason,
+        };
+        std.get(states, s, '400,tedge_custom_mapper,"Unexpected operation state. id=%s, state=%s"' % [id, s])
+      ;
+
+      {
+        raw_message: getTemplate(status),
+        topic: 'c8y/s/us/%s' % ctx.serial,
       }

--- a/routes/c8y-operations-json.yaml
+++ b/routes/c8y-operations-json.yaml
@@ -169,9 +169,9 @@ routes:
               type: type,
               modules: [
                 {
-                  name: software.name,
+                  name: std.get(software, 'name'),
                   version: std.strReplace(software.version, "::" + type, ""),
-                  action: software.action,
+                  action: std.get(software, 'action', 'install'),
                 }
                 for software in message.payload.c8y_SoftwareUpdate
                 if std.get(software, 'softwareType', defaultType) == type


### PR DESCRIPTION
* Use local child id for child operations
* Add child software update handling
* Harden software operation parsing (don't assume fields exists)
* Add demo to show the tedge-mapper-agent functionality