### PR TITLE
feat: support multiple topics per route

### DIFF
--- a/cmd/routes_check.go
+++ b/cmd/routes_check.go
@@ -67,7 +67,7 @@ Examples:
 					for _, route := range routes {
 						if !route.Skip {
 							if !route.Match(msg.Topic) {
-								slog.Debug("Route did not match topic.", "route", route.Name, "root_topic", route.Topic, "topic", topic)
+								slog.Debug("Route did not match topic.", "route", route.Name, "root_topic", route.DisplayTopics(), "topic", topic)
 								continue
 							}
 
@@ -85,7 +85,7 @@ Examples:
 								return
 							}
 
-							if stop := service.DisplayMessage(fmt.Sprintf("%s (%s)", route.Name, route.Topic), &imsg, output, cmd.ErrOrStderr(), compact); stop {
+							if stop := service.DisplayMessage(fmt.Sprintf("%s (%s)", route.Name, route.DisplayTopics()), &imsg, output, cmd.ErrOrStderr(), compact); stop {
 								done <- struct{}{}
 								return
 							}

--- a/pkg/routes/routes.go
+++ b/pkg/routes/routes.go
@@ -17,7 +17,7 @@ type Specification struct {
 
 type Route struct {
 	Name         string        `yaml:"name"`
-	Topic        string        `yaml:"topic"`
+	Topics       []string      `yaml:"topics"`
 	Skip         bool          `yaml:"skip"`
 	Template     Template      `yaml:"template"`
 	PreProcessor *PreProcessor `yaml:"preprocessor,omitempty"`
@@ -34,6 +34,14 @@ type PreProcessor struct {
 	Fields         []string `yaml:"fields"`
 	fixedFields    []string
 	variableFields []string
+}
+
+func (r *Route) DisplayTopics(sep ...string) string {
+	delim := ", "
+	if len(sep) > 0 {
+		delim = sep[0]
+	}
+	return strings.Join(r.Topics, delim)
 }
 
 func (r *Route) PreparePreProcessor() error {
@@ -126,7 +134,12 @@ func routeSplit(route string) []string {
 // match takes the topic string of the published message and does a basic compare to the
 // string of the current Route, if they match it returns true
 func (r *Route) Match(topic string) bool {
-	return r.Topic == topic || routeIncludesTopic(r.Topic, topic)
+	for _, routeTopic := range r.Topics {
+		if routeTopic == topic || routeIncludesTopic(routeTopic, topic) {
+			return true
+		}
+	}
+	return false
 }
 
 func (r *Route) ExecutePreprocessor(in string) (string, error) {

--- a/pkg/routes/routes_test.go
+++ b/pkg/routes/routes_test.go
@@ -96,7 +96,7 @@ func Test_RoutePatternMatch(t *testing.T) {
 
 	for _, c := range testcases {
 		route := Route{
-			Topic: c.TopicPattern,
+			Topics: []string{c.TopicPattern},
 		}
 		assert.Equal(t, c.Expected, route.Match(c.Topic))
 	}

--- a/pkg/service/factory.go
+++ b/pkg/service/factory.go
@@ -196,9 +196,9 @@ func NewDefaultService(broker string, clientID string, cleanSession bool, routeD
 
 	for _, route := range routes {
 		if !route.Skip {
-			slog.Info("Registering route.", "name", route.Name, "topic", route.Topic)
+			slog.Info("Registering route.", "name", route.Name, "topics", route.DisplayTopics())
 			err = app.Register(
-				route.Topic,
+				route.Topics,
 				1,
 				NewStreamFactory(
 					app.Client,
@@ -213,7 +213,7 @@ func NewDefaultService(broker string, clientID string, cleanSession bool, routeD
 				return nil, err
 			}
 		} else {
-			slog.Info("Ignoring route marked as skip.", "name", route.Name, "topic", route.Topic)
+			slog.Info("Ignoring route marked as skip.", "name", route.Name, "topics", route.DisplayTopics())
 		}
 	}
 	return app, nil

--- a/pkg/service/factory_test.go
+++ b/pkg/service/factory_test.go
@@ -12,8 +12,8 @@ import (
 
 func Test_RemoveContext(t *testing.T) {
 	route := routes.Route{
-		Name:  "Recursive route",
-		Topic: "in",
+		Name:   "Recursive route",
+		Topics: []string{"in"},
 		Template: routes.Template{
 			Type: "jsonnet",
 			Value: `
@@ -71,8 +71,8 @@ func Test_RemoveContext(t *testing.T) {
 
 func Test_MaxDepthLimit(t *testing.T) {
 	recursiveRoute := routes.Route{
-		Name:  "Recursive route",
-		Topic: "in",
+		Name:   "Recursive route",
+		Topics: []string{"in"},
 		Template: routes.Template{
 			Type: "jsonnet",
 			Value: heredoc.Doc(`
@@ -86,8 +86,8 @@ func Test_MaxDepthLimit(t *testing.T) {
 		},
 	}
 	nonRecursiveRoute := routes.Route{
-		Name:  "Non recursive route",
-		Topic: "in",
+		Name:   "Non recursive route",
+		Topics: []string{"in"},
 		Template: routes.Template{
 			Type: "jsonnet",
 			Value: heredoc.Doc(`

--- a/routes/c8y-operations-json.yaml
+++ b/routes/c8y-operations-json.yaml
@@ -2,7 +2,8 @@
 ---
 routes:
 - name: c8y-devicecontrol-notifications
-  topic: c8y/devicecontrol/notifications
+  topics:
+    - c8y/devicecontrol/notifications
   template:
     type: jsonnet
     value: |
@@ -59,7 +60,8 @@ routes:
       }
 
 - name: shell-operation
-  topic: c8y/devicecontrol/notifications/+/c8y_Command
+  topics:
+    - c8y/devicecontrol/notifications/+/c8y_Command
   template:
     type: jsonnet
     value: |
@@ -80,7 +82,8 @@ routes:
       }
 
 - name: restart-operation
-  topic: c8y/devicecontrol/notifications/+/c8y_Restart
+  topics:
+    - c8y/devicecontrol/notifications/+/c8y_Restart
   template:
     type: jsonnet
     value: |
@@ -97,7 +100,8 @@ routes:
       }
 
 - name: upload-config-operation
-  topic: c8y/devicecontrol/notifications/+/c8y_UploadConfigFile
+  topics:
+    - c8y/devicecontrol/notifications/+/c8y_UploadConfigFile
   template:
     type: jsonnet
     value: |
@@ -121,7 +125,8 @@ routes:
       }
 
 - name: download-config-operation
-  topic: c8y/devicecontrol/notifications/+/c8y_DownloadConfigFile
+  topics:
+    - c8y/devicecontrol/notifications/+/c8y_DownloadConfigFile
   template:
     type: jsonnet
     value: |
@@ -142,7 +147,8 @@ routes:
       }
 
 - name: software-update-operation
-  topic: c8y/devicecontrol/notifications/+/c8y_SoftwareUpdate
+  topics:
+    - c8y/devicecontrol/notifications/+/c8y_SoftwareUpdate
   template:
     type: jsonnet
     value: |
@@ -186,7 +192,8 @@ routes:
       }
   
 - name: firmware-update-operation
-  topic: c8y/devicecontrol/notifications/+/c8y_Firmware
+  topics:
+    - c8y/devicecontrol/notifications/+/c8y_Firmware
   template:
     type: jsonnet
     value: |
@@ -214,7 +221,8 @@ routes:
       }
 
 - name: unknown-operation
-  topic: c8y/devicecontrol/notifications/+/unknown
+  topics:
+    - c8y/devicecontrol/notifications/+/unknown
   template:
     type: jsonnet
     value: |
@@ -231,7 +239,8 @@ routes:
 # Operation Transitions
 #
 - name: software update (main device)
-  topic: tedge/commands/res/software/update
+  topics:
+    - tedge/commands/res/software/update
   description: Handle the operation updates and send the status back to the cloud
   template:
     type: jsonnet
@@ -255,7 +264,8 @@ routes:
       }
 
 - name: software update (child devices)
-  topic: tedge/+/commands/res/software/update
+  topics:
+    - tedge/+/commands/res/software/update
   description: Handle the operation updates and send the status back to the cloud
   template:
     type: jsonnet

--- a/routes/c8y-operations-smartrest-alt.yaml
+++ b/routes/c8y-operations-smartrest-alt.yaml
@@ -4,7 +4,8 @@ disable: true
 routes:
 - name: Cumulocity Operation Mapper Without Preprocessor
   skip: true
-  topic: c8y/s/ds
+  topics:
+    - c8y/s/ds
   template:
     type: jsonnet
     value: |

--- a/routes/c8y-operations-smartrest.yaml
+++ b/routes/c8y-operations-smartrest.yaml
@@ -3,7 +3,8 @@
 disable: true
 routes:
 - name: c8y-operation-smartrest
-  topic: c8y/s/ds
+  topics:
+    - c8y/s/ds
   preprocessor:
     type: csv
     fields:
@@ -20,7 +21,8 @@ routes:
       }
 
 - name: shell-operation
-  topic: c8y/s/ds/511
+  topics:
+    - c8y/s/ds/511
   preprocessor:
     type: csv
     fields:
@@ -39,7 +41,8 @@ routes:
       }
 
 - name: download-config-operation
-  topic: c8y/s/ds/524
+  topics:
+    - c8y/s/ds/524
   preprocessor:
     type: csv
     fields:
@@ -57,7 +60,8 @@ routes:
       }
 
 - name: firmware-update-operation
-  topic: c8y/s/ds/515
+  topics:
+    - c8y/s/ds/515
   preprocessor:
     type: csv
     fields:
@@ -76,7 +80,8 @@ routes:
       }
 
 - name: software-update-operation
-  topic: c8y/s/ds/529
+  topics:
+    - c8y/s/ds/529
   preprocessor:
     type: csv
     fields:

--- a/routes/tedge-healthcheck-monitor.yaml
+++ b/routes/tedge-healthcheck-monitor.yaml
@@ -2,7 +2,8 @@
 ---
 routes:
 - name: monitor 
-  topic: tedge/health/+
+  topics:
+    - tedge/health/+
   description: |
     Create events when a service health changes (or is re-sent)
 

--- a/spec/schema.json
+++ b/spec/schema.json
@@ -13,21 +13,24 @@
                 "skip": {
                     "type": "boolean"
                 },
-                "topic": {
-                    "anyOf": [
-                        {"type": "string"},
-                        {
-                            "type": "string",
-                            "enum": [
-                                "tedge/measurements",
-                                "tedge/measurements/+",
-                                "tedge/events/+",
-                                "tedge/events/+/+",
-                                "tedge/alarms/+",
-                                "tedge/alarms/+/+"
-                            ]
-                        }
-                    ]
+                "topics": {
+                    "type": "array",
+                    "items": {
+                        "anyOf": [
+                            {"type": "string"},
+                            {
+                                "type": "string",
+                                "enum": [
+                                    "tedge/measurements",
+                                    "tedge/measurements/+",
+                                    "tedge/events/+",
+                                    "tedge/events/+/+",
+                                    "tedge/alarms/+",
+                                    "tedge/alarms/+/+"
+                                ]
+                            }
+                        ]
+                    }
                 },
                 "template": {
                     "$ref": "#/definitions/template"
@@ -35,7 +38,8 @@
                 "preprocessor": {
                     "$ref": "#/definitions/preprocessor"
                 }
-            }
+            },
+            "required": ["topics"]
         },
         "preprocessor": {
             "type": "object",


### PR DESCRIPTION
Add support for subscribing to multiple MQTT topics for a specific route. This allows users to create a single route to handle multiple MQTT topic structures.