### PR TITLE
feat: support options in csv preprocessor (delimiter and trimspace)

### DIFF
--- a/pkg/routes/routes_test.go
+++ b/pkg/routes/routes_test.go
@@ -56,6 +56,39 @@ func TestCSVPreprocessor(t *testing.T) {
 	assert.Equal(t, newMessage.Software[1].Url, "http://hello.world2.com")
 }
 
+func TestCSVPreprocessorWithCustomOptions(t *testing.T) {
+	route := &Route{
+		PreProcessor: &PreProcessor{
+			Type:      "csv",
+			Delimiter: ":",
+			TrimSpace: true,
+			Fields: []string{
+				"time",
+				"val1",
+				"val2",
+			},
+		},
+	}
+
+	if err := route.PreparePreProcessor(); err != nil {
+		t.Errorf("Prepare preprocessor failed. got=%s", err)
+	}
+
+	out, err := route.ExecutePreprocessor("1684945201.643:2:12510 ")
+	if err != nil {
+		t.Errorf("Expected no error. got=%s", err)
+	}
+
+	assert.JSONEq(t, `
+	{
+		"time": "1684945201.643",
+		"val1": "2",
+		"val2": "12510",
+		"payload": "1684945201.643:2:12510 "
+	}
+	`, out)
+}
+
 func Test_RoutePatternMatch(t *testing.T) {
 	testcases := []struct {
 		TopicPattern string

--- a/spec/schema.json
+++ b/spec/schema.json
@@ -50,6 +50,14 @@
                         "csv"
                     ]
                 },
+                "delimiter": {
+                    "type": "string",
+                    "maxLength": 1
+                },
+                "trimspace": {
+                    "type": "boolean",
+                    "default": true
+                },
                 "fields": {
                     "type": "array",
                     "items": {


### PR DESCRIPTION
feat: support options in csv preprocessor (delimiter and trimspace)

* `trimspace` will remove any leading and trailing space from each field. Trim space will not be applied to the payload
* `delimiter` will control which character should be used instead of comma (limited to 1 character only)
* Proprocessing blocks will also remove any NUL charactoers 0x00 from the input text (as this generally causes problems with parsing)