### PR TITLE
feat: route check cli improvements

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -89,4 +89,6 @@ func init() {
 	rootCmd.PersistentFlags().Bool("timestamps", true, "Show date/time in log entries")
 	rootCmd.PersistentFlags().String("dir", "routes", "Route directory")
 	rootCmd.PersistentFlags().Int("maxdepth", 3, "Maximum recursion depth")
+	rootCmd.PersistentFlags().Duration("delay", 2*time.Second, "Delay to wait after publishing a message (by the same route) (to prevent spamming)")
+	rootCmd.PersistentFlags().Bool("dry", false, "Dry run mode. Don't send any requests")
 }

--- a/cmd/serve.go
+++ b/cmd/serve.go
@@ -7,7 +7,6 @@ import (
 	"os"
 	"os/signal"
 	"syscall"
-	"time"
 
 	"github.com/reubenmiller/tedge-mapper-template/pkg/service"
 	"github.com/spf13/cobra"
@@ -16,7 +15,6 @@ import (
 
 var ArgBroker string
 var ArgClientID string
-var ArgDelay time.Duration
 var ArgCleanSession bool
 
 // serveCmd represents the serve command
@@ -39,8 +37,10 @@ Examples:
 		debug, _ := cmd.Root().PersistentFlags().GetBool("debug")
 		routeDir, _ := cmd.Root().PersistentFlags().GetString("dir")
 		maxDepth, _ := cmd.Root().PersistentFlags().GetInt("maxdepth")
+		delay, _ := cmd.Root().PersistentFlags().GetDuration("delay")
+		dryRun, _ := cmd.Root().PersistentFlags().GetBool("dry")
 
-		app, err := service.NewDefaultService(ArgBroker, ArgClientID, ArgCleanSession, "", routeDir, maxDepth, ArgDelay, debug, false)
+		app, err := service.NewDefaultService(ArgBroker, ArgClientID, ArgCleanSession, "", routeDir, maxDepth, delay, debug, dryRun)
 		if err != nil {
 			return err
 		}
@@ -64,5 +64,4 @@ func init() {
 	serveCmd.Flags().StringVar(&ArgBroker, "host", "localhost:1883", "Broker endpoint (can included port number)")
 	serveCmd.Flags().BoolVar(&ArgCleanSession, "clean", true, "Clean session")
 	serveCmd.Flags().StringVarP(&ArgClientID, "clientid", "i", "tedge-mapper-template", "MQTT client id")
-	serveCmd.Flags().DurationVar(&ArgDelay, "delay", 2*time.Second, "Delay to wait after publishing a message (to prevent spamming)")
 }

--- a/go.mod
+++ b/go.mod
@@ -9,6 +9,7 @@ require (
 	github.com/google/go-jsonnet v0.20.0
 	github.com/lmittmann/tint v0.3.3
 	github.com/mattn/go-colorable v0.1.13
+	github.com/mattn/go-isatty v0.0.19
 	github.com/reubenmiller/go-c8y v0.14.0
 	github.com/spf13/cobra v1.7.0
 	github.com/stretchr/testify v1.8.3
@@ -27,7 +28,6 @@ require (
 	github.com/google/go-querystring v1.1.0 // indirect
 	github.com/gorilla/websocket v1.5.0 // indirect
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
-	github.com/mattn/go-isatty v0.0.18 // indirect
 	github.com/obeattie/ohmyglob v0.0.0-20150811221449-290764208a0d // indirect
 	github.com/op/go-logging v0.0.0-20160315200505-970db520ece7 // indirect
 	github.com/pkg/errors v0.9.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -28,8 +28,8 @@ github.com/lmittmann/tint v0.3.3/go.mod h1:QsxOuHxDBzUhLS7uPgRmMIEXe21fADGyaGCGu
 github.com/mattn/go-colorable v0.1.13 h1:fFA4WZxdEF4tXPZVKMLwD8oUnCTTo08duU7wxecdEvA=
 github.com/mattn/go-colorable v0.1.13/go.mod h1:7S9/ev0klgBDR4GtXTXX8a3vIGJpMovkB8vQcUbaXHg=
 github.com/mattn/go-isatty v0.0.16/go.mod h1:kYGgaQfpe5nmfYZH+SKPsOc2e4SrIfOl2e/yFXSvRLM=
-github.com/mattn/go-isatty v0.0.18 h1:DOKFKCQ7FNG2L1rbrmstDN4QVRdS89Nkh85u68Uwp98=
-github.com/mattn/go-isatty v0.0.18/go.mod h1:W+V8PltTTMOvKvAeJH7IuucS94S2C6jfK/D7dTCTo3Y=
+github.com/mattn/go-isatty v0.0.19 h1:JITubQf0MOLdlGRuRq+jtsDlekdYPia9ZFsB8h/APPA=
+github.com/mattn/go-isatty v0.0.19/go.mod h1:W+V8PltTTMOvKvAeJH7IuucS94S2C6jfK/D7dTCTo3Y=
 github.com/obeattie/ohmyglob v0.0.0-20150811221449-290764208a0d h1:SIsYJszBZOjUGo91Z3x3LufvYRZ2CwB+F4EKK5b53iw=
 github.com/obeattie/ohmyglob v0.0.0-20150811221449-290764208a0d/go.mod h1:hFInPnl2+HgL1AruAAgDGZa0EQBpTLIMU0PObAVi1ow=
 github.com/op/go-logging v0.0.0-20160315200505-970db520ece7 h1:lDH9UUVJtmYCjyT0CI4q8xvlXPxeZ0gYCVvWbmPlp88=

--- a/pkg/jsonnet/jsonnet.go
+++ b/pkg/jsonnet/jsonnet.go
@@ -22,8 +22,9 @@ type JsonnetEngine struct {
 }
 
 type EngineOptions struct {
-	Debug bool
-	Meta  any
+	Debug  bool
+	DryRun bool
+	Meta   any
 }
 
 type TemplateOption func(*EngineOptions) *EngineOptions
@@ -31,6 +32,13 @@ type TemplateOption func(*EngineOptions) *EngineOptions
 func WithDebug(v bool) TemplateOption {
 	return func(opt *EngineOptions) *EngineOptions {
 		opt.Debug = v
+		return opt
+	}
+}
+
+func WithDryRun(v bool) TemplateOption {
+	return func(opt *EngineOptions) *EngineOptions {
+		opt.DryRun = v
 		return opt
 	}
 }
@@ -93,6 +101,10 @@ func getParameter(parameters []interface{}, i int) any {
 
 func (e *JsonnetEngine) Debug() bool {
 	return e.Options.Debug
+}
+
+func (e *JsonnetEngine) DryRun() bool {
+	return e.Options.DryRun
 }
 
 func (e *JsonnetEngine) addFunctions() {

--- a/pkg/service/factory.go
+++ b/pkg/service/factory.go
@@ -60,7 +60,7 @@ func NewStreamFactory(client mqtt.Client, apiClient *APIClient, route routes.Rou
 
 		sm, err := stream.Process(topic, message)
 		if err != nil {
-			slog.Error("Invalid process m.", err)
+			slog.Error("Template error.", "route", route.Name, "error", err)
 			return nil, err
 		}
 

--- a/pkg/template/template.go
+++ b/pkg/template/template.go
@@ -3,4 +3,5 @@ package template
 type Templater interface {
 	Execute(string, string) (string, error)
 	Debug() bool
+	DryRun() bool
 }


### PR DESCRIPTION
feat: route check cli improvements

* Support reading message from file (auto detected)
* Disable color when output is not a terminal
* Support dry run in engine (but routes check always uses dry run)
* Improve template error message to also show route name where the template is coming from