### PR TITLE
feat: support reading routes from multiple directories

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -87,7 +87,7 @@ func init() {
 	rootCmd.PersistentFlags().BoolP("silent", "s", false, "Silent mode. Only log warnings and errors (shortcut for --loglevel=warn)")
 	rootCmd.PersistentFlags().String("loglevel", "info", "Log level: debug, info, warn, error")
 	rootCmd.PersistentFlags().Bool("timestamps", true, "Show date/time in log entries")
-	rootCmd.PersistentFlags().String("dir", "routes", "Route directory")
+	rootCmd.PersistentFlags().StringSlice("dir", []string{"routes"}, "Route directory (more than 1 can be provided)")
 	rootCmd.PersistentFlags().Int("maxdepth", 3, "Maximum recursion depth")
 	rootCmd.PersistentFlags().Duration("delay", 2*time.Second, "Delay to wait after publishing a message (by the same route) (to prevent spamming)")
 	rootCmd.PersistentFlags().Bool("dry", false, "Dry run mode. Don't send any requests")

--- a/cmd/serve.go
+++ b/cmd/serve.go
@@ -29,18 +29,21 @@ Examples:
 	tedge-mapper-template serve --dir routes
 	# Start the mapper and use any routes defined under the ./routes directory
 
+	tedge-mapper-template serve --dir routes --dir routes-simulation
+	# Start the mapper and look for routes in multiple directories
+
 	tedge-mapper-template serve --host 'otherhost:1883'
 	# Start the mapper using a custom MQTT broker endpoint
 	`,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		slog.Info("Starting listener")
 		debug, _ := cmd.Root().PersistentFlags().GetBool("debug")
-		routeDir, _ := cmd.Root().PersistentFlags().GetString("dir")
+		routeDirs, _ := cmd.Root().PersistentFlags().GetStringSlice("dir")
 		maxDepth, _ := cmd.Root().PersistentFlags().GetInt("maxdepth")
 		delay, _ := cmd.Root().PersistentFlags().GetDuration("delay")
 		dryRun, _ := cmd.Root().PersistentFlags().GetBool("dry")
 
-		app, err := service.NewDefaultService(ArgBroker, ArgClientID, ArgCleanSession, "", routeDir, maxDepth, delay, debug, dryRun)
+		app, err := service.NewDefaultService(ArgBroker, ArgClientID, ArgCleanSession, "", routeDirs, maxDepth, delay, debug, dryRun)
 		if err != nil {
 			return err
 		}

--- a/pkg/service/factory.go
+++ b/pkg/service/factory.go
@@ -258,14 +258,14 @@ func NewMetaData() map[string]any {
 	return meta
 }
 
-func NewDefaultService(broker string, clientID string, cleanSession bool, httpEndpoint string, routeDir string, maxdepth int, postDelay time.Duration, debug bool, dryRun bool) (*Service, error) {
+func NewDefaultService(broker string, clientID string, cleanSession bool, httpEndpoint string, routeDirs []string, maxdepth int, postDelay time.Duration, debug bool, dryRun bool) (*Service, error) {
 	app, err := NewService(broker, clientID, cleanSession, httpEndpoint, dryRun)
 	if err != nil {
 		return nil, err
 	}
 
 	meta := NewMetaData()
-	routes := app.ScanMappingFiles(routeDir)
+	routes := app.ScanMappingFiles(routeDirs)
 
 	for _, route := range routes {
 		if !route.Skip {
@@ -285,7 +285,7 @@ func NewDefaultService(broker string, clientID string, cleanSession bool, httpEn
 				),
 			)
 			if err != nil {
-				return nil, err
+				slog.Warn("Failed to register route. It will be ignored.", "name", route.Name, "error", err)
 			}
 		} else {
 			slog.Info("Ignoring route marked as skip.", "name", route.Name, "topics", route.DisplayTopics())


### PR DESCRIPTION
Both the `routes check` and `serve` support reading routes located in multiple directories.

This makes it easier to include/exclude groups of routes by just adding or removing the associated `--dir <path>` flag.

**Example**

Look for routes in two directories, where one routes are the production routes, and the second directory contains some routes which act as simulators to test out the production routes (to allow for end-to-end route checks!)

```
go run main.go --dir routes-prod --dir routes-simulation
```
