### PR TITLE
feat: provide option for users to set a default device-id via a flag

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -91,4 +91,5 @@ func init() {
 	rootCmd.PersistentFlags().Int("maxdepth", 3, "Maximum recursion depth")
 	rootCmd.PersistentFlags().Duration("delay", 2*time.Second, "Delay to wait after publishing a message (by the same route) (to prevent spamming)")
 	rootCmd.PersistentFlags().Bool("dry", false, "Dry run mode. Don't send any requests")
+	rootCmd.PersistentFlags().String("device-id", "", "Default device.id to use if the tedge configuration is not provided")
 }

--- a/cmd/routes_check.go
+++ b/cmd/routes_check.go
@@ -27,8 +27,9 @@ them against a given topic and message.
 
 Examples:
 
-	tedge-mapper-template routes check -t 'c8y/s/ds' -m '524,DeviceSerial,http://www.my.url,type'
-	# Check handling of routes for the 'c8y/s/ds' topic with a given message payload
+	tedge-mapper-template routes check -t 'c8y/s/ds' -m '524,DeviceSerial,http://www.my.url,type' --device-id sim_tedge0
+	# Check handling of routes for the 'c8y/s/ds' topic with a given message payload.
+	# A custom device-id is also provided for testing.
 
 	tedge-mapper-template routes check -t 'c8y/s/ds' -m ./operation.json
 	# Check handling of routes and read the message from file
@@ -42,6 +43,7 @@ Examples:
 		compact, _ := cmd.Flags().GetBool("compact")
 		maxDepth, _ := cmd.Root().PersistentFlags().GetInt("maxdepth")
 		delay, _ := cmd.Root().PersistentFlags().GetDuration("delay")
+		deviceID, _ := cmd.Root().PersistentFlags().GetString("device-id")
 		// dryRun, _ := cmd.Root().PersistentFlags().GetBool("dry")
 		// Force dry run
 		dryRun := true
@@ -66,11 +68,18 @@ Examples:
 			message = string(b)
 		}
 
-		app, err := service.NewDefaultService(ArgBroker, ArgClientID, ArgCleanSession, "", routeDirs, maxDepth, delay, debug, true)
+		app, err := service.NewDefaultService(ArgBroker, ArgClientID, ArgCleanSession, "", routeDirs, maxDepth, delay, debug, true, []service.MetaOption{
+			service.WithMetaDefaultDeviceID(deviceID),
+		})
 		if err != nil {
 			return err
 		}
-		meta := service.NewMetaData()
+
+		// TODO: Provide the meta data as part of the service
+		// and access via app.GetMeta()
+		meta := service.NewMetaData(
+			service.WithMetaDefaultDeviceID(deviceID),
+		)
 
 		slog.Debug("Total routes.", "count", len(app.Routes))
 

--- a/cmd/serve.go
+++ b/cmd/serve.go
@@ -42,8 +42,11 @@ Examples:
 		maxDepth, _ := cmd.Root().PersistentFlags().GetInt("maxdepth")
 		delay, _ := cmd.Root().PersistentFlags().GetDuration("delay")
 		dryRun, _ := cmd.Root().PersistentFlags().GetBool("dry")
+		deviceID, _ := cmd.Root().PersistentFlags().GetString("device-id")
 
-		app, err := service.NewDefaultService(ArgBroker, ArgClientID, ArgCleanSession, "", routeDirs, maxDepth, delay, debug, dryRun)
+		app, err := service.NewDefaultService(ArgBroker, ArgClientID, ArgCleanSession, "", routeDirs, maxDepth, delay, debug, dryRun, []service.MetaOption{
+			service.WithMetaDefaultDeviceID(deviceID),
+		})
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
Support the `--device-id <name>` flag on both check and serve. This allows users to test out their routes without having to set a magic environment variable on systems where tedge is not installed/configured