### PR TITLE
Feat-simulation-routes

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -127,6 +127,9 @@ nfpms:
         dst: /etc/tedge-mapper-template/routes/
         type: config|noreplace
 
+      - src: routes-simulation/*.yaml
+        dst: /etc/tedge-mapper-template/routes-simulation/
+        type: config|noreplace
 
 # brews:
 #   -

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,23 @@
+{
+    // Use IntelliSense to learn about possible attributes.
+    // Hover to view descriptions of existing attributes.
+    // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "name": "Debug",
+            "type": "go",
+            "request": "launch",
+            "mode": "auto",
+            "envFile": "${workspaceFolder}/.env",
+            "program": "${workspaceFolder}/main.go",
+            "args": [
+                "routes",
+                "check",
+                "-t", "c8y/devicecontrol/notifications",
+                "-m", "${file}",
+                "--device-id", "sim_tedge01"
+            ]
+        }
+    ]
+}

--- a/demo/images/files/50-main-setup.sh
+++ b/demo/images/files/50-main-setup.sh
@@ -10,6 +10,13 @@ CHILD_DIR="/etc/tedge/operations/c8y/${DEVICE_ID}_${CHILD}"
 sudo -u tedge mkdir -p "$CHILD_DIR"
 sudo -u tedge touch "$CHILD_DIR/c8y_SoftwareUpdate"
 
+# TODO: The following are enabled but don't fully work yet
+sudo -u tedge touch "$CHILD_DIR/c8y_Firmware"
+sudo -u tedge touch "$CHILD_DIR/c8y_Restart"
+sudo -u tedge touch "$CHILD_DIR/c8y_DownloadConfigFile"
+sudo -u tedge touch "$CHILD_DIR/c8y_UploadConfigFile"
+sudo -u tedge touch "$CHILD_DIR/c8y_LogfileRequest"
+
 echo "Stopping tedge-mapper-c8y"
 sudo systemctl disable tedge-mapper-c8y
 sudo systemctl stop tedge-mapper-c8y

--- a/docs/TOPICS.md
+++ b/docs/TOPICS.md
@@ -1,0 +1,21 @@
+# Topics
+
+## firmware operation (c8y-firmware-plugin)
+
+### Topics used to start the firmware update and the public status afterwards
+
+```sh
+tedge/child01/commands/firmware_update/start
+tedge/child01/commands/firmware_update/executing
+tedge/child01/commands/firmware_update/done/successful
+tedge/child01/commands/firmware_update/done/failed
+```
+
+### Child device topics
+
+These topics should only be used to communicate information between the c8y-firmware-plugin and the child device connector.
+
+```sh
+tedge/child01/commands/req/firmware_update
+tedge/child01/commands/res/firmware_update
+```

--- a/routes-simulation/child/child-simulator.yaml
+++ b/routes-simulation/child/child-simulator.yaml
@@ -1,0 +1,111 @@
+# yaml-language-server: $schema=../../spec/schema.json
+---
+routes:
+
+#---------------------------------#
+# c8y-firmware-plugin-simulator
+#---------------------------------#
+
+- name: simulation - firmware plugin - send to a device
+  topics:
+    - tedge/commands/firmware_update/start
+    - tedge/+/commands/firmware_update/start
+  template:
+    type: jsonnet
+    value: |
+      local prefix = std.split(topic, "/commands/")[0];
+      {
+        topic: "%s/commands/req/firmware_update" % prefix,
+        message: message,
+      }
+
+- name: simulation - firmware plugin - set to done (so it can publish)
+  skip: true
+  topics:
+    - tedge/commands/firmware_update/done/successful
+    - tedge/+/commands/firmware_update/done/successful
+  template:
+    type: jsonnet
+    value: |
+      local prefix = std.split(topic, "/commands/")[0];
+      {
+        topic: "%s/commands/firmware_update/done" % prefix,
+        message: message,
+      }
+
+#---------------------------------#
+# child device firmware simulator
+#---------------------------------#
+- name: simulation - device - set to executing
+  topics:
+    - tedge/commands/req/firmware_update
+    - tedge/+/commands/req/firmware_update
+  template:
+    type: jsonnet
+    value: |
+      local prefix = std.split(topic, "/commands/")[0];
+      {
+        topic: "%s/commands/res/firmware_update" % prefix,
+        message: message + {
+          status: "executing",
+        },
+        # skip: std.get(message, 'status', '')
+      }
+
+- name: simulation - device - set to successful
+  description: Only trigger on executing messages (as it is a self referencing message)
+  topics:
+    - tedge/commands/res/firmware_update
+    - tedge/+/commands/res/firmware_update
+  template:
+    type: jsonnet
+    value: |
+      local prefix = std.split(topic, "/commands/")[0];
+      local incomingStatus = std.get(message, 'status', '');
+      {
+        topic: "%s/commands/firmware_update/done/successful" % prefix,
+        message: message + {
+          status: "successful",
+        },
+        skip: incomingStatus != "executing",
+      }
+
+#---------------------------------#
+# main device software simulator
+#---------------------------------#
+- name: simulation - software - set to executing
+  topics:
+    - tedge/commands/req/software/update
+    - tedge/+/commands/req/software/update
+  template:
+    type: jsonnet
+    value: |
+      local prefix = std.split(topic, "/commands/")[0];
+      local incomingStatus = std.get(message, 'status', '');
+      {
+        topic: "%s/commands/res/software/update" % prefix,
+        message: {
+          id: message.id,
+          status: 'successful',
+          currentSoftwareList: [
+            {
+              type: "apt",
+              modules: [
+                {
+                  name: "curl",
+                  version: "7.74.0-1.3+deb11u7"
+                },
+                {
+                  name: "package2",
+                  version: "2.0.0"
+                }
+              ]
+            },
+            {
+              type: "dummy",
+              modules: []
+            }
+          ]
+        },
+        context: false,
+      }

--- a/routes/c8y-operations-json.yaml
+++ b/routes/c8y-operations-json.yaml
@@ -21,6 +21,49 @@ routes:
         }[std.type(any)](any)
       );
 
+      # Ref: https://groups.google.com/g/jsonnet/c/1nEJOYmS78I
+      local m = {
+          get(o, f, default)::
+              local get_(o, ks) =
+                  if ! std.objectHas(o, ks[0]) then
+                      default
+                  else if std.length(ks) == 1 then
+                      o[ks[0]]
+                  else
+                      get_(o[ks[0]], ks[1:]);
+
+              get_(o, std.split(f, '.')),
+          
+        has(o, f)::
+          local has_(o, ks) =
+              if ! std.objectHas(o, ks[0]) then
+                  false
+              else if std.length(ks) == 1 then
+                  true
+              else
+                  has_(o[ks[0]], ks[1:]);
+          has_(o, std.split(f, '.')),
+        
+        trimPrefix(s, prefix)::
+          if s != '' && prefix != '' then
+            if std.startsWith(s, prefix) then
+              s[std.length(prefix):]
+            else
+              s
+          else
+            s
+      };
+
+      local trimPrefix = function(s, prefix)
+        if s != '' && prefix != '' then
+          if std.startsWith(s, prefix) then
+            s[std.length(prefix):]
+          else
+            s
+        else
+          s
+      ;
+
       local detectType = function(m, prefix='', defaultType='unknown')
         {
           local _matches = [
@@ -41,24 +84,26 @@ routes:
             ),
             _ctx: {
               local _ctx = self,
-              local external_childid = _.Get(message, 'deviceExternalIDs.externalIds.0.externalId', null),
-              local external_id = _.Get(message, 'externalSource.externalId', 'not-set'),
               local device_id = std.get(meta, 'device_id', ''),
 
-              serial: if external_childid != null then external_childid else external_id, 
-              localSerial: if std.startsWith(_ctx.serial, device_id) then _ctx.serial[std.length(device_id)+1:] else _ctx.serial,
+              serial: m.get(message, 'externalSource.externalId', ''),
+              localSerial: m.trimPrefix(_ctx.serial, device_id + '_'),
 
               deviceID: std.get(message, 'deviceId', ''),
               agentID: std.get(message, 'agentId', ''),
               operationID: std.get(message, 'id', ''),
               opType: detectType(message, 'c8y_', 'unknown').type,
-              id: _.ID(),
+              id: if _ctx.operationID != "" then _ctx.operationID else _.ID(),
             },
           },
           topic: 'c8y/devicecontrol/notifications/' + $.message._ctx.serial + '/' + $.message._ctx.opType,
+          skip: $.message._ctx.serial == '',
           end: false,
       }
 
+#
+# Shell/Command operation
+#
 - name: shell-operation
   topics:
     - c8y/devicecontrol/notifications/+/c8y_Command
@@ -81,6 +126,9 @@ routes:
           topic: build_topic('operations/command'),
       }
 
+#
+# Restart
+#
 - name: restart-operation
   topics:
     - c8y/devicecontrol/notifications/+/c8y_Restart
@@ -99,6 +147,9 @@ routes:
           topic: build_topic('control/restart'),
       }
 
+#
+# Configuration
+#
 - name: upload-config-operation
   topics:
     - c8y/devicecontrol/notifications/+/c8y_UploadConfigFile
@@ -146,6 +197,9 @@ routes:
           topic: build_topic('config_update'),
       }
 
+#
+# Software
+#
 - name: software-update-operation
   topics:
     - c8y/devicecontrol/notifications/+/c8y_SoftwareUpdate
@@ -187,39 +241,164 @@ routes:
           ]
         },
         topic: build_topic('software/update'),
-        end: true,
         context: false,
       }
-  
+
+#
+# Firmware
+#
 - name: firmware-update-operation
+  description: Incoming Firmware update operation
   topics:
     - c8y/devicecontrol/notifications/+/c8y_Firmware
   template:
     type: jsonnet
     value: |
-      local build_topic = function(partial)
+      local build_tedge_topic = function(partial)
         local device_id = std.get(meta, 'device_id', '');
         if ctx.serial == device_id || ctx.serial == 'not-set'  then
-          'tedge/commands/req/' + partial
+          'tedge/commands/%s' % partial
         else
-          'tedge/%/commands/req/%s' % [ctx.localSerial, partial]
+          'tedge/%s/commands/%s' % [ctx.localSerial, partial]
       ;
 
       local params = std.get(message.payload, ctx.opType, {});
+      assert 'name' in params : ".name is missing: opType=" + ctx.opType;
 
       {
         message: {
-          id: if 'operationID' in ctx then ctx.operationID else ctx.ID,
+          id: if 'operationID' in ctx then ctx.operationID else ctx.id,
           name: params.name,
           url: params.url,
           version: params.version,
           sha256: '',
         },
-        topic: build_topic('firmware_update'),
-        end: true,
+        topic: build_tedge_topic('firmware_update/start'),
         context: false,
       }
 
+- name: firmware-update-operation-done
+  description: Update the firmware list in Cumulocity
+  topics:
+    - tedge/+/commands/firmware_update/done/failed
+    - tedge/+/commands/firmware_update/done/successful
+  template:
+    type: jsonnet
+    value: |
+      local sourceDevice = std.split(topic, '/')[1];
+      local build_smartrest_topic = function(base_topic)
+        local device_id = std.get(meta, 'device_id', '');
+
+        if sourceDevice == device_id || sourceDevice == 'not-set'  then
+          base_topic
+        else
+          '%s/%s' % [base_topic, device_id + '_' + sourceDevice]
+      ;
+
+      {
+        updates: [
+          {
+            local firmwareName = std.get(message, 'name', ''),
+            local firmwareVersion = std.get(message, 'version', ''),
+            local firmwareUrl = std.get(message, 'url', ''),
+
+            topic: build_smartrest_topic('c8y/s/us'),
+            message: "115,%s,%s,%s" % [firmwareName, firmwareVersion, firmwareUrl],
+          }
+        ],
+        topic: 'tedge/+/commands/firmware_update/done',
+        message: message,
+        context: true,
+      }
+
+- name: set-operation-to-executing
+  description: Set any Cumulocity operation to executing
+  topics:
+    - tedge/+/commands/+/executing
+  template:
+    type: jsonnet
+    value: |
+      assert 'id' in message : 'Message must container a .id value';
+      {
+        api: {
+          path: "/devicecontrol/operations/%s" % message.id,
+          method: "PUT",
+        },
+        message: message + {
+          id:: null,
+          startedAt: _.Now(),
+        },
+        context: false,
+      }
+
+- name: set-operation-to-done
+  description: Set any Cumulocity operation to either SUCCESSFUL or FAILED
+  topics:
+    - tedge/+/commands/+/done
+  template:
+    type: jsonnet
+    value: |
+      assert 'id' in message : 'Message must contain an .id property';
+      assert 'status' in message : 'Message must contain an .status property';
+
+      local c8yStatus = std.asciiUpper(message.status);
+
+      {
+        api: {
+          path: "/devicecontrol/operations/%s" % message.id,
+          method: "PUT",
+        },
+        message: message + {
+          id:: null,  # id must be excluded from the update request
+          status: c8yStatus,
+          [if c8yStatus == "FAILED" then 'failureReason']: std.get(message, 'reason', 'no reason given'),
+        },
+        context: false,
+      }
+
+- name: deprecate-c8y-operation-update
+  skip: true
+  description: Generic Cumulocity update operation via REST API
+  topics:
+    - c8y/devicecontrol/notifications/+/c8y
+  template:
+    type: jsonnet
+    value: |
+      # Fail early if the operation is missing required data
+      assert "id" in message : "Message must contain a .id property";
+      assert "status" in message : "Message must contain a .status property";
+
+      # Allowed operation statues
+      local getOperationStatus = function(value)
+        std.get(
+          {
+            successful: "SUCCESSFUL",
+            failed: "FAILED",
+            executing: "EXECUTING",
+            pending: "PENDING",
+          },
+          std.asciiLower(value),
+          'FAILED'
+        )
+      ;
+
+      local status = getOperationStatus(message.status);
+      {
+        api: {
+          path: "/devicecontrol/operations/%s" % message.id,
+          method: "PUT",
+        },
+        message: message + {
+          id:: null,  # id must be excluded from the update request
+          status: status,
+          [if status == "FAILED" then 'failureReason']: std.get(message, 'reason', 'no reason given'),
+        },
+        context: false,
+      }
+
+#
+# Unknown operations
+#
 - name: unknown-operation
   topics:
     - c8y/devicecontrol/notifications/+/unknown
@@ -237,6 +416,10 @@ routes:
 
 #
 # Operation Transitions
+#
+
+#
+# Software
 #
 - name: software update (main device)
   topics:

--- a/tests/messages/child/firmware-update.golden
+++ b/tests/messages/child/firmware-update.golden
@@ -1,0 +1,148 @@
+Route: c8y-devicecontrol-notifications (c8y/devicecontrol/notifications)
+
+Input Message
+  topic:    c8y/devicecontrol/notifications
+
+Output Message (mqtt)
+  topic:    c8y/devicecontrol/notifications/sim_tedge01_child01/c8y_Firmware
+
+    {
+      "_ctx": {
+        "agentID": "612000655",
+        "deviceID": "862000795",
+        "id": "2021340",
+        "localSerial": "child01",
+        "lvl": 1,
+        "opType": "c8y_Firmware",
+        "operationID": "2021340",
+        "serial": "sim_tedge01_child01"
+      },
+      "payload": {
+        "agentId": "612000655",
+        "c8y_Firmware": {
+          "name": "iot-linux",
+          "url": "https://example.com",
+          "version": "1.0.0"
+        },
+        "creationTime": "2023-05-25T08:58:19.504Z",
+        "delivery": {
+          "log": [],
+          "status": "PENDING",
+          "time": "2023-05-25T08:58:19.927Z"
+        },
+        "description": "Update firmware to: \"iot-linux\" (version: 1.0.0)",
+        "deviceId": "862000795",
+        "externalSource": {
+          "externalId": "sim_tedge01_child01",
+          "type": "c8y_Serial"
+        },
+        "id": "2021340",
+        "status": "PENDING"
+      }
+    }
+
+Route: firmware-update-operation (c8y/devicecontrol/notifications/+/c8y_Firmware)
+
+Input Message
+  topic:    c8y/devicecontrol/notifications/sim_tedge01_child01/c8y_Firmware
+
+Output Message (mqtt)
+  topic:    tedge/child01/commands/firmware_update/start
+
+    {
+      "id": "2021340",
+      "name": "iot-linux",
+      "sha256": "",
+      "url": "https://example.com",
+      "version": "1.0.0"
+    }
+
+Route: simulation - firmware plugin - send to a device (tedge/commands/firmware_update/start, tedge/+/commands/firmware_update/start)
+
+Input Message
+  topic:    tedge/child01/commands/firmware_update/start
+
+Output Message (mqtt)
+  topic:    tedge/child01/commands/req/firmware_update
+
+    {
+      "id": "2021340",
+      "name": "iot-linux",
+      "sha256": "",
+      "url": "https://example.com",
+      "version": "1.0.0"
+    }
+
+Route: simulation - device - set to executing (tedge/commands/req/firmware_update, tedge/+/commands/req/firmware_update)
+
+Input Message
+  topic:    tedge/child01/commands/req/firmware_update
+
+Output Message (mqtt)
+  topic:    tedge/child01/commands/res/firmware_update
+
+    {
+      "id": "2021340",
+      "name": "iot-linux",
+      "sha256": "",
+      "status": "executing",
+      "url": "https://example.com",
+      "version": "1.0.0"
+    }
+
+Route: simulation - device - set to successful (tedge/commands/res/firmware_update, tedge/+/commands/res/firmware_update)
+
+Input Message
+  topic:    tedge/child01/commands/res/firmware_update
+
+Output Message (mqtt)
+  topic:    tedge/child01/commands/firmware_update/done/successful
+
+    {
+      "id": "2021340",
+      "name": "iot-linux",
+      "sha256": "",
+      "status": "successful",
+      "url": "https://example.com",
+      "version": "1.0.0"
+    }
+
+Route: firmware-update-operation-done (tedge/+/commands/firmware_update/done/failed, tedge/+/commands/firmware_update/done/successful)
+
+Input Message
+  topic:    tedge/child01/commands/firmware_update/done/successful
+
+Output Updates
+  topic:    c8y/s/us/sim_tedge01_child01
+
+115,iot-linux,1.0.0,https://example.com
+
+
+Output Message (mqtt)
+  topic:    tedge/+/commands/firmware_update/done
+
+    {
+      "id": "2021340",
+      "name": "iot-linux",
+      "sha256": "",
+      "status": "successful",
+      "url": "https://example.com",
+      "version": "1.0.0"
+    }
+
+Route: set-operation-to-done (tedge/+/commands/+/done)
+
+Input Message
+  topic:    tedge/+/commands/firmware_update/done
+
+Output Message (api)
+  request:  PUT /devicecontrol/operations/2021340
+
+    {
+      "name": "iot-linux",
+      "sha256": "",
+      "status": "SUCCESSFUL",
+      "url": "https://example.com",
+      "version": "1.0.0"
+    }
+

--- a/tests/messages/child/firmware-update.json
+++ b/tests/messages/child/firmware-update.json
@@ -1,0 +1,22 @@
+{
+    "agentId": "612000655",
+    "c8y_Firmware": {
+        "name": "iot-linux",
+        "url": "https://example.com",
+        "version": "1.0.0"
+    },
+    "creationTime": "2023-05-25T08:58:19.504Z",
+    "delivery": {
+        "log": [],
+        "status": "PENDING",
+        "time": "2023-05-25T08:58:19.927Z"
+    },
+    "description": "Update firmware to: \"iot-linux\" (version: 1.0.0)",
+    "deviceId": "862000795",
+    "externalSource": {
+        "externalId": "sim_tedge01_child01",
+        "type": "c8y_Serial"
+    },
+    "id": "2021340",
+    "status": "PENDING"
+}

--- a/tests/messages/child/software-update.json
+++ b/tests/messages/child/software-update.json
@@ -1,0 +1,27 @@
+{
+    "delivery": {
+        "log": [],
+        "time": "2023-05-25T20:29:04.787Z",
+        "status": "PENDING"
+    },
+    "agentId": "281072059",
+    "creationTime": "2023-05-25T20:29:04.737Z",
+    "deviceId": "211072248",
+    "id": "2029526",
+    "status": "PENDING",
+    "description": "Apply software changes: install \"dummy1\" (version: 1.0.0::dummy)",
+    "c8y_SoftwareUpdate": [
+        {
+            "softwareType": "dummy",
+            "name": "dummy1",
+            "action": "install",
+            "id": "372001201",
+            "version": "1.0.0::dummy",
+            "url": " "
+        }
+    ],
+    "externalSource": {
+        "externalId": "sim_tedge01_child01",
+        "type": "c8y_Serial"
+    }
+}


### PR DESCRIPTION
Add routes for firmware update handling and simulation routes to mimic the newly proposed topics of the c8y-firmware-plugin.