### PR TITLE
fix: firmware update routes to work with another experiment

### DIFF
--- a/routes-simulation/child/child-simulator.yaml
+++ b/routes-simulation/child/child-simulator.yaml
@@ -16,7 +16,9 @@ routes:
       local prefix = std.split(topic, "/commands/")[0];
       {
         topic: "%s/commands/req/firmware_update" % prefix,
-        message: message,
+        message: message + {
+          attempt: std.get(message, 'attempt', 0) + 1,
+        },
       }
 
 - name: simulation - firmware plugin - set to done (so it can publish)

--- a/routes/c8y-operations-json.yaml
+++ b/routes/c8y-operations-json.yaml
@@ -285,6 +285,11 @@ routes:
   template:
     type: jsonnet
     value: |
+      local prefix = std.split(topic, "/commands/")[0];
+
+      # TODO: Get the status from the message body
+      local status = std.split(topic, "/done/")[1];
+
       local sourceDevice = std.split(topic, '/')[1];
       local build_smartrest_topic = function(base_topic)
         local device_id = std.get(meta, 'device_id', '');
@@ -306,8 +311,8 @@ routes:
             message: "115,%s,%s,%s" % [firmwareName, firmwareVersion, firmwareUrl],
           }
         ],
-        topic: 'tedge/+/commands/firmware_update/done',
-        message: message,
+        topic: '%s/commands/firmware_update/done' % prefix,
+        message: {status: status} + message,
         context: true,
       }
 
@@ -327,6 +332,7 @@ routes:
         message: message + {
           id:: null,
           startedAt: _.Now(),
+          status: 'EXECUTING',
         },
         context: false,
       }

--- a/routes/c8y-operations-json.yaml
+++ b/routes/c8y-operations-json.yaml
@@ -268,6 +268,7 @@ routes:
       {
         message: {
           id: if 'operationID' in ctx then ctx.operationID else ctx.id,
+          device: ctx.localSerial,
           name: params.name,
           url: params.url,
           version: params.version,


### PR DESCRIPTION
Updating the firmware update routes to work with the generic c8y-firmware-plugin (which does not have any c8y related calls in it, except maybe the jwt token).