### PR TITLE
fix(route-check): don't show cli usage on template errors

### DIFF
--- a/cmd/routes_check.go
+++ b/cmd/routes_check.go
@@ -134,7 +134,8 @@ Examples:
 					if err != nil {
 						slog.Error("handler returned an error.", "err", err)
 
-						// Return errors immediately
+						// Return errors immediately (but don't trigger the command's help text)
+						cmd.SilenceUsage = true
 						return err
 					}
 


### PR DESCRIPTION
Don't clutter the cli output with the cli usage on template errors (as it makes the template error hard to see)