### PR TITLE
feat(routes): add example c8y routes for registration and inventory updates

### DIFF
--- a/demo/justfile
+++ b/demo/justfile
@@ -10,8 +10,8 @@ down:
     docker compose down -v
 
 # Bootstrap
-bootstrap:
-    docker compose exec tedge env C8Y_BASEURL=${C8Y_BASEURL:-} C8Y_USER=${C8Y_USER:-} C8Y_PASSWORD=${C8Y_PASSWORD:-} DEVICE_ID=${DEVICE_ID:-} bootstrap.sh --install --install-sourcedir /setup/build/
+bootstrap *args='':
+    docker compose exec tedge env C8Y_BASEURL=${C8Y_BASEURL:-} C8Y_USER=${C8Y_USER:-} C8Y_PASSWORD=${C8Y_PASSWORD:-} DEVICE_ID=${DEVICE_ID:-} bootstrap.sh --install --install-sourcedir /setup/build/ {{args}}
     docker compose exec child01 bootstrap.sh
 
 # Shell into main device

--- a/docs/EXAMPLES.md
+++ b/docs/EXAMPLES.md
@@ -92,13 +92,13 @@ The fragment in the topic will be used to place the payload like so:
 **Main Device**
 
 ```sh
-tedge mqtt pub tedge/inventory/update/custom '{"os":"Debian 11"}'
+tedge mqtt pub tedge/inventory/update/custom '{"os":"Debian 12"}'
 ```
 
 **Child device**
 
 ```sh
-tedge mqtt pub tedge/child01/inventory/update/custom '{"os":"Debian 11"}'
+tedge mqtt pub tedge/child01/inventory/update/custom '{"os":"Debian 12"}'
 ```
 
 ### Deleting a fragment

--- a/docs/EXAMPLES.md
+++ b/docs/EXAMPLES.md
@@ -1,0 +1,123 @@
+# Examples
+
+A collection of examples which are provided by the in-built routes.
+
+## Child device registration
+
+Child devices can be registered to the main device or other child devices. This level is currently limited to children of children (2 level device hierarchy, however this will likely be lifted in the future).
+
+Child devices can be registered with some additional information which let's thin-edge.io know what functionality is supported by the device. An example of the the payload used to register a child device is shown below.
+
+```json
+{
+    "requiredInterval": 10,
+    "supportedOperations": [
+        "c8y_Restart",
+        "c8y_SoftwareUpdate"
+    ],
+}
+```
+
+|Property|Description|Example|
+|--|--|--|
+|`requiredInterval`|Required interval in minutes.|`30`|
+|`supportedOperations`|List of operations which the child device supports|`["c8y_Restart"]`|
+
+### Register a child device
+
+**Topic**
+
+A child device can be registered to the main device using the following topic.
+
+```sh
+tedge/register/child/{child}
+```
+
+**Example**
+
+```sh
+tedge mqtt pub tedge/register/child/child10 '{"supportedOperations":["c8y_Restart", "c8y_SoftwareUpdate"]}'
+```
+
+### Register a child device of an existing child device
+
+```sh
+tedge mqtt pub tedge/child10/register/child/child10_01 '{"supportedOperations":["c8y_Restart", "c8y_SoftwareUpdate"]}'
+```
+
+tedge mqtt pub tedge/child10/register/child/child10_03 '{"supportedOperations":["c8y_Restart", "c8y_SoftwareUpdate"],"requiredInterval":10}'
+
+## Inventory updates
+
+### Inventory updates
+
+Updating multiple properties on the root level or non-object updates (like strings, numbers or boolean).
+
+```sh
+tedge mqtt pub "tedge/inventory/update" '{"type":"mytype", "custom":{"os":"Debian 11"}}'
+tedge mqtt pub "tedge/{child}/inventory/update" '{"type":"mytype", "custom":{"os":"Debian 11"}}'
+```
+
+**Main Device**
+
+```sh
+tedge mqtt pub tedge/inventory/update '{"custom":{"os":"Debian 11"}}'
+```
+
+**Child device**
+
+```sh
+tedge mqtt pub tedge/child01/inventory/update '{"custom":{"os":"Debian 11"}}'
+```
+
+### Partial inventory updates
+
+Properties on the root level can also be updated by using the topic structure (currently only the root level is supported). This is the preferred method to update fragments as it allows other components to listen to a subset of changes, rather than every inventory update.
+
+```sh
+tedge mqtt pub "tedge/inventory/update/{fragment}" '{"os":"Debian 11"}'
+tedge mqtt pub "tedge/{child}/inventory/update/{fragment}" '{"os":"Debian 11"}'
+```
+
+The fragment in the topic will be used to place the payload like so:
+
+```json
+{
+    "{fragment}": {
+        "os": "Debian 11"
+    }
+}
+```
+
+**Main Device**
+
+```sh
+tedge mqtt pub tedge/inventory/update/custom '{"os":"Debian 11"}'
+```
+
+**Child device**
+
+```sh
+tedge mqtt pub tedge/child01/inventory/update/custom '{"os":"Debian 11"}'
+```
+
+### Deleting a fragment
+
+Single fragments can be deleted using the following topics.
+
+```sh
+tedge mqtt pub "tedge/inventory/delete/{fragment}" ''
+tedge mqtt pub "tedge/{child}/inventory/delete/{fragment}" ''
+```
+
+**Main Device**
+
+```sh
+tedge mqtt pub tedge/inventory/delete/custom ''
+```
+
+**Child device**
+
+```sh
+tedge mqtt pub tedge/child01/inventory/delete ''
+```

--- a/justfile
+++ b/justfile
@@ -3,6 +3,18 @@
 default:
     @just --list -f "{{justfile()}}"
 
+# Start the demo with the latest built package
+demo arch='arm64' args='--no-prompt':
+    just release-local
+    rm -f demo/dist/tedge-mapper-template*.deb
+    cp dist/tedge-mapper-template_*{{arch}}*deb demo/dist/
+    cd demo && just up
+    cd demo && just bootstrap {{args}}
+
+# Open a shell on the demo (if running)
+demo-shell:
+    cd demo && just shell-main
+
 # Install dev dependencies
 setup-dev:
     go install github.com/reubenmiller/commander/v3/cmd/commander@v3.0.2

--- a/lib/tedge.libsonnet
+++ b/lib/tedge.libsonnet
@@ -7,4 +7,51 @@
         else
             '%s/%s' % [prefix, serial]
     ,
+
+    #
+    # Get the external id from a topic.
+    # e.g. it will convert:
+    #   tedge => device_id
+    #   tedge/child01 => device_id/child01
+    #
+    getSerial(topic, parent='', prefix='tedge')::
+        if topic == prefix then
+            parent
+        else
+            local name = 
+                if std.startsWith(topic, prefix) then
+                    std.lstripChars(topic[std.length(prefix):], "/")
+                else
+                    topic
+            ;
+            if parent == name then
+                parent
+            else
+                '%s_%s' % [parent, name]
+    ,
+
+    #
+    # Get the smart rest topic related to the device
+    # e.g. it will convert
+    #   tedge => c8y/s/us
+    #   tedge/child01 => c8y/s/us/tedge01_child01
+    #
+    getSmartRestTopic(topic, parent='', smartrest='c8y/s/us', prefix='tedge')::
+        local serial = $.getSerial(topic, parent, prefix);
+        local tmp =
+            if serial == parent then
+                ""
+            else
+                serial
+        ;
+
+        std.rstripChars(
+            "%s/%s" % [smartrest, tmp],
+            "/"
+        )
+    ,
+
+    getExternalId(items=[], sep='_')::
+        std.join(sep, items)
+    ,
 }

--- a/routes/c8y-inventory-updates.yaml
+++ b/routes/c8y-inventory-updates.yaml
@@ -1,0 +1,82 @@
+# yaml-language-server: $schema=../spec/schema.json
+---
+routes:
+- name: c8y-inventory-update
+  topics:
+    - tedge/inventory/update
+    - tedge/+/inventory/update
+  description: |
+    Support inventory updates via a new tedge interface
+
+    Updates are sent to Cumulocity IoT via the JSON via MQTT interface.
+
+  template:
+    type: jsonnet
+    value: |
+      local tedge = import 'tedge.libsonnet';
+      local prefix = std.split(topic, '/inventory/update')[0];
+      local serial = tedge.getSerial(prefix, meta.device_id);
+      assert std.isObject(message) : 'Invalid message. Only objects are accepted';
+      
+      {
+        topic: 'c8y/inventory/managedObjects/update/%s' % serial,
+        message: message + {
+          id:: null,
+          creationTime:: null,
+          lastUpdated:: null,
+        },
+        skip: std.length($.message) == 0,
+      }
+
+- name: c8y-inventory-update-partial
+  topics:
+    - tedge/inventory/update/+
+    - tedge/+/inventory/update/+
+  description: |
+    Support inventory updates via a new tedge interface
+
+    Updates are sent to Cumulocity IoT via the JSON via MQTT interface.
+
+  template:
+    type: jsonnet
+    value: |
+      local tedge = import 'tedge.libsonnet';
+      local prefix = std.split(topic, '/inventory/update')[0];
+      local serial = tedge.getSerial(prefix, meta.device_id);
+
+      local fragment = std.splitLimitR(topic, "/", 1)[1];
+      
+      assert std.isObject(message) : 'Invalid message. Only objects are accepted';
+      
+      {
+        topic: 'c8y/inventory/managedObjects/update/%s' % serial,
+        context: false,
+        message: {
+          [fragment]: message,
+        },
+        skip: std.isEmpty(fragment),
+      }
+
+- name: c8y-inventory-delete-fragment
+  topics:
+    - tedge/inventory/delete/+
+    - tedge/+/inventory/delete/+
+  description: |
+    Remove fragment from the device's managed object (main or child device)
+
+  template:
+    type: jsonnet
+    value: |
+      local tedge = import 'tedge.libsonnet';
+
+      local prefix = std.split(topic, '/inventory/delete')[0];
+      local serial = tedge.getSerial(prefix, meta.device_id);
+
+      local outTopic = tedge.getSmartRestTopic(prefix, meta.device_id, 'c8y/s/us');
+      local fragment = std.splitLimitR(topic, "/", 1)[1];
+      
+      {
+        topic: outTopic,
+        context: false,
+        raw_message: '107,%s' % fragment,
+      }

--- a/routes/c8y-register.yaml
+++ b/routes/c8y-register.yaml
@@ -1,0 +1,57 @@
+# yaml-language-server: $schema=../spec/schema.json
+---
+routes:
+- name: c8y-registration-child
+  topics:
+    - tedge/register/child/+
+    - tedge/+/register/child/+
+  description: |
+    Register a child device
+
+    Documentation: https://cumulocity.com/guides/reference/smartrest-two/#101
+
+    101,uniqueChildId,myChildDevice,myChildType
+    114,c8y_Restart,c8y_Configuration,c8y_SoftwareList
+
+
+  template:
+    type: jsonnet
+    value: |
+      local tedge = import 'tedge.libsonnet';
+      local prefix = std.split(topic, '/register/child/')[0];
+      local name = std.splitLimitR(topic, "/", 1)[1];
+      local outTopic = tedge.getSmartRestTopic(prefix, meta.device_id, 'c8y/s/us');
+      local childSerial = tedge.getExternalId([meta.device_id, name]);
+
+      assert std.isObject(message) : 'Invalid message. Only objects are accepted';
+
+      # set defaults
+      local messageWithDefaults = {
+        requiredInterval: 30,
+      } + message;
+
+      {
+        topic: outTopic,
+        updates: [
+          # Note: this message needs to be delayed until after the registration has happened
+          local supportedTypes = std.get(message, 'supportedOperations', []);
+          {
+            topic: 'c8y/s/us/%s' % childSerial,
+            message: "114,%s" % std.join(",", supportedTypes),
+            delay: 5, # Delay publishing until after the registration message has been sent
+            skip: std.length(supportedTypes) == 0,
+          },
+
+          {
+            topic: 'c8y/s/us/%s' % childSerial,
+            message: "117,%s" % messageWithDefaults.requiredInterval,
+            delay: 6,
+            skip: !std.isNumber(messageWithDefaults.requiredInterval),
+          },
+        ],
+        raw_message: '101,"%s","%s","%s"' % [
+          childSerial,
+          std.get(message, 'name', name),
+          std.get(message, 'type', 'c8y_MQTTChildDevice'),
+        ],
+      }

--- a/tests/c8y-inventory-updates-tests.yaml
+++ b/tests/c8y-inventory-updates-tests.yaml
@@ -1,0 +1,123 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/reubenmiller/commander/feat/handle-nested-files/schema.json
+
+config:
+  env:
+    C8Y_SETTINGS_DEFAULTS_CACHE: true
+
+tests:
+  main device - update without name in topic:
+    command: |
+      go run main.go routes check --dir ./routes --dir ./routes-simulation/child -t tedge/inventory/update -m '{"custom":{"fragment":true}}' -s --device-id sim_tedge01
+    stdout:
+      exactly: |
+        Route: c8y-inventory-update (tedge/inventory/update, tedge/+/inventory/update)
+
+        Input Message
+          topic:    tedge/inventory/update
+
+        Output Message (mqtt)
+          topic:    c8y/inventory/managedObjects/update/sim_tedge01
+
+            {
+              "custom": {
+                "fragment": true
+              }
+            }
+
+  main device - update using device name in topic:
+    command: |
+      go run main.go routes check --dir ./routes -t tedge/sim_tedge01/inventory/update -m '{"custom":{"fragment":true}}' -s --device-id sim_tedge01
+    stdout:
+      exactly: |
+        Route: c8y-inventory-update (tedge/inventory/update, tedge/+/inventory/update)
+
+        Input Message
+          topic:    tedge/sim_tedge01/inventory/update
+
+        Output Message (mqtt)
+          topic:    c8y/inventory/managedObjects/update/sim_tedge01
+
+            {
+              "custom": {
+                "fragment": true
+              }
+            }
+
+  Send inventory update for main device with empty message:
+    command: |
+      go run main.go routes check --dir ./routes -t tedge/inventory/update -m '{}' -s --device-id sim_tedge01
+    stdout:
+      exactly: |
+        Route: c8y-inventory-update (tedge/inventory/update, tedge/+/inventory/update)
+
+        Input Message
+          topic:    tedge/inventory/update
+
+        Output Message (mqtt)
+          topic:    c8y/inventory/managedObjects/update/sim_tedge01
+
+  Send inventory update for child device:
+    command: |
+      go run main.go routes check --dir ./routes -t tedge/child01/inventory/update -m '{"custom":{"fragment":true}}' -s --device-id sim_tedge01
+    stdout:
+      exactly: |
+        Route: c8y-inventory-update (tedge/inventory/update, tedge/+/inventory/update)
+
+        Input Message
+          topic:    tedge/child01/inventory/update
+
+        Output Message (mqtt)
+          topic:    c8y/inventory/managedObjects/update/sim_tedge01_child01
+
+            {
+              "custom": {
+                "fragment": true
+              }
+            }
+
+  main device - partial update:
+    command: |
+      go run main.go routes check --dir ./routes --dir ./routes-simulation/child -t tedge/inventory/update/running_state -m '{"state":"RETRY"}' -s --device-id sim_tedge01
+    stdout:
+      exactly: |
+        Route: c8y-inventory-update-partial (tedge/inventory/update/+, tedge/+/inventory/update/+)
+
+        Input Message
+          topic:    tedge/inventory/update/running_state
+
+        Output Message (mqtt)
+          topic:    c8y/inventory/managedObjects/update/sim_tedge01
+
+            {
+              "running_state": {
+                "state": "RETRY"
+              }
+            }
+
+  main device - remove fragment:
+    command: |
+      go run main.go routes check --dir ./routes --dir ./routes-simulation/child -t tedge/inventory/delete/running_state -m '' -s --device-id sim_tedge01
+    stdout:
+      exactly: |
+        Route: c8y-inventory-delete-fragment (tedge/inventory/delete/+, tedge/+/inventory/delete/+)
+
+        Input Message
+          topic:    tedge/inventory/delete/running_state
+
+        Output Message (mqtt)
+          topic:    c8y/s/us
+        107,running_state
+
+  child device - remove fragment:
+    command: |
+      go run main.go routes check --dir ./routes --dir ./routes-simulation/child -t tedge/child01/inventory/delete/running_state -m '' -s --device-id sim_tedge01
+    stdout:
+      exactly: |
+        Route: c8y-inventory-delete-fragment (tedge/inventory/delete/+, tedge/+/inventory/delete/+)
+
+        Input Message
+          topic:    tedge/child01/inventory/delete/running_state
+
+        Output Message (mqtt)
+          topic:    c8y/s/us/sim_tedge01_child01
+        107,running_state

--- a/tests/c8y-register-tests.yaml
+++ b/tests/c8y-register-tests.yaml
@@ -1,0 +1,90 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/reubenmiller/commander/feat/handle-nested-files/schema.json
+
+config:
+  env:
+    C8Y_SETTINGS_DEFAULTS_CACHE: true
+
+tests:
+  register child device:
+    command: |
+      go run main.go routes check --dir ./routes --dir ./routes-simulation/child -t tedge/register/child/child01 -m '{}' -s --device-id sim_tedge01
+    stdout:
+      exactly: |
+        Route: c8y-registration-child (tedge/register/child/+, tedge/+/register/child/+)
+
+        Input Message
+          topic:    tedge/register/child/child01
+
+        Output Updates
+          topic:    c8y/s/us/sim_tedge01_child01 (delayed: 6.0s)
+
+        117,30
+
+
+        Output Message (mqtt)
+          topic:    c8y/s/us
+        101,"sim_tedge01_child01","child01","c8y_MQTTChildDevice"
+
+  register child device with custom name and type:
+    command: |
+      go run main.go routes check --dir ./routes --dir ./routes-simulation/child -t tedge/register/child/child01 -m '{"name":"My custom name","type":"mytype"}' -s --device-id sim_tedge01
+    stdout:
+      exactly: |
+        Route: c8y-registration-child (tedge/register/child/+, tedge/+/register/child/+)
+
+        Input Message
+          topic:    tedge/register/child/child01
+
+        Output Updates
+          topic:    c8y/s/us/sim_tedge01_child01 (delayed: 6.0s)
+
+        117,30
+
+
+        Output Message (mqtt)
+          topic:    c8y/s/us
+        101,"sim_tedge01_child01","My custom name","mytype"
+
+  register child device of a child device:
+    command: |
+      go run main.go routes check --dir ./routes --dir ./routes-simulation/child -t tedge/child01/register/child/child02 -m '{"name":"My custom name","type":"mytype"}' -s --device-id sim_tedge01
+    stdout:
+      exactly: |
+        Route: c8y-registration-child (tedge/register/child/+, tedge/+/register/child/+)
+
+        Input Message
+          topic:    tedge/child01/register/child/child02
+
+        Output Updates
+          topic:    c8y/s/us/sim_tedge01_child02 (delayed: 6.0s)
+
+        117,30
+
+
+        Output Message (mqtt)
+          topic:    c8y/s/us/sim_tedge01_child01
+        101,"sim_tedge01_child02","My custom name","mytype"
+
+  register child device with additional information:
+    command: |
+      go run main.go routes check --dir ./routes --dir ./routes-simulation/child -t tedge/child01/register/child/child02 -m '{"supportedOperations":["c8y_Restart","c8y_SoftwareUpdate"],"requiredInterval":24}' -s --device-id sim_tedge01
+    stdout:
+      exactly: |
+        Route: c8y-registration-child (tedge/register/child/+, tedge/+/register/child/+)
+
+        Input Message
+          topic:    tedge/child01/register/child/child02
+
+        Output Updates
+          topic:    c8y/s/us/sim_tedge01_child02 (delayed: 5.0s)
+
+        114,c8y_Restart,c8y_SoftwareUpdate
+
+          topic:    c8y/s/us/sim_tedge01_child02 (delayed: 6.0s)
+
+        117,24
+
+
+        Output Message (mqtt)
+          topic:    c8y/s/us/sim_tedge01_child01
+        101,"sim_tedge01_child02","child02","c8y_MQTTChildDevice"


### PR DESCRIPTION
Add some example routes to gain experience on some modified topic structures.

Routes were added to provide:

* update and delete fragments
* register child device and supported operations